### PR TITLE
FreeBSDでのビルドに対応　#!/bin/bash -> #!/usr/bin/env bash

### DIFF
--- a/add-relinks.sh
+++ b/add-relinks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for example in $(ls examples); do
   if [[ -d examples/${example} ]]; then

--- a/check-line-length.sh
+++ b/check-line-length.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 WHITELIST=(
   ./examples/lifetime/borrow/borrow.rs

--- a/check-links.sh
+++ b/check-links.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# 
-# Extract links from Markdown documents, and check 
-# their HTTP status. Flag anything that doesn't 
+#
+# Extract links from Markdown documents, and check
+# their HTTP status. Flag anything that doesn't
 # return a 200.
-# 
+#
 
 DELIMITER="{{-%%-}}"
 
@@ -15,40 +15,40 @@ any_bad_links=false
 files=$(find ./examples -name "*.md")
 
 for file in $files ; do
-  
-  # 
+
+  #
   # Extract the urls, if any, along with the line numbers.
-  # 
+  #
   reference_style_links=$(grep -n "^\[[^]]\+\]:\ http" $file | \
                           sed -e "s/:/$DELIMITER/" -e "s/\[[^]]*\]: //")
-  
+
   inline_links=$(grep -no "\[[^]]\+\]([^[:space:]]\+)" $file | \
                  sed -e "s/:/$DELIMITER/" -e "s/\[[^]]*\](//" -e "s/)$//")
-    
+
   if [[ $reference_style_links == "" && $inline_links == "" ]]; then
     continue
   elif [[ $reference_style_links == "" ]]; then
     all_links="$inline_links"
   elif [[ $inline_links == "" ]]; then
     all_links="$reference_style_links"
-  else    
+  else
     all_links=$(echo "$reference_style_links"$'\n'"$inline_links" | sort -n)
   fi
-    
+
   for link in $all_links ; do
-    
+
     url=$(echo $link | awk -F"$DELIMITER" '{print $2}')
-    
+
     # Check relative, internal, urls
     if [[ ! $url == http://* ]] && [[ ! $url == https://* ]]; then
-        
+
         local_path=$url
-        
+
         # Remove the .html if present
         if [[ $local_path == *.html ]]; then
             local_path=${local_path:0:${#local_path}-5}
         fi
-        
+
         # Build the local directory path
         # This depends on the GitBook style directory structure
         if [[ ! $local_path == /* ]]; then
@@ -56,35 +56,35 @@ for file in $files ; do
         else
             local_path="./examples$local_path"
         fi
-        
+
         if [[ -d $local_path ]]; then
             continue
         fi
-        
+
         status_code="404"
-        
+
     # Check external urls
     else
-        
+
         # -s: silent
         # -L: follow redirect
         # -o: send output to /dev/null
         # -I: load headers only
         # -w: write the status code to stdout
         status_code=$(curl -s -L -o /dev/null -I -w "%{http_code}" "$url")
-    
+
         if [[ $status_code == "200" ]]; then
           continue
-        fi  
+        fi
     fi
-        
+
     any_bad_links=true
-    
+
     line_number=$(echo $link | awk -F"$DELIMITER" '{print $1}')
-    
+
     echo -e "Bad link in $file:$line_number [$status_code] $url"
   done
-  
+
 done
 
 if $any_bad_links; then

--- a/counter.sh
+++ b/counter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "counting total line number foreach chapters"
 echo "output file is count_table"
 echo "" > count_table

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rev=$(git rev-parse --short HEAD)
 

--- a/fix-edit-button.sh
+++ b/fix-edit-button.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for example in $(find examples -type d -name "*"); do
   html=stage/_book/${example#examples/}.html

--- a/setup-stage.sh
+++ b/setup-stage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ace_repository='https://github.com/ajaxorg/ace-builds/trunk/src-min'
 ace_playpen_local='node_modules/gitbook-plugin-rust-playpen'


### PR DESCRIPTION
ビルド用の各種シェルスクリプトでは、shebang が `#!/bin/bash` となっていますが、FreeBSD では bash が `/usr/local/bin/bash` にインストールされているので動きません。

そこで、shebang を、Linux、OS X、FreeBSD（などの *BSD 系 OS）の全てに通用する、`#!/usr/bin/env bash` に変更させてください。
