### PR TITLE
CI のスキップ

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+general:
+  branches:
+    ignore:
+      # https://circleci.com/docs/configuration/#branches
+      - /.*/ # ignore all branches (regex)
+
+machine:
+  timezone:
+    Asia/Tokyo

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,6 +20,14 @@ git fetch upstream && git reset upstream/gh-pages
 cp -r ../../vendor/gitbook/* gitbook/
 echo "rust-lang-ja.org" > CNAME
 
+# Create circle.yml to disable CI on gh-pages branch.
+cat > circle.yml <<EOF
+general:
+  branches:
+    ignore:
+      - gh-pages
+EOF
+
 touch .
 
 git add -A .


### PR DESCRIPTION
本リポジトリを CircleCI に [登録しました](https://circleci.com/gh/rust-lang-ja/rust-by-example-ja) が、設定が正しく終わるまでは、CI をスキップするようにします。この PR をマージすると、master ブランチと gh-pages で、CI がスキップされるようになります。

なお、deploy.sh も変更してますが、自分の環境だとテストが面倒なので試してません。大丈夫だと思いますが、deploy.sh を実行して、もしなにか問題があったら、issue をオープンしてください。

他の既存のブランチでは、git push する毎に CI が走ってしまいます。CI をスキップするためには、それらのブランチに、このコミットを取り込んでください。（例：`git rebase -i master` でリベース後に `git push -f` で強制 push する。または、`git cherry-pick` を使うなど）
