### PR TITLE
誤植を修正

### DIFF
--- a/examples/error/unwrap/unwrap.rs
+++ b/examples/error/unwrap/unwrap.rs
@@ -9,7 +9,7 @@ fn give_commoner(gift: Option<&str>) {
     }
 }
 
-// 温室育ちのお姫様はヘビを見ると`panic`します。
+// 王室育ちのお姫様はヘビを見ると`panic`します。
 fn give_princess(gift: Option<&str>) {
     // `unwrap`を使用すると値が`None`だった際に`panic`を返します。。
     let inside = gift.unwrap();


### PR DESCRIPTION
``王室`` が ``温室`` になっていたので修正しました。