### PR TITLE
Fix typo and improve translation.

### DIFF
--- a/examples/hello/print/print_display/display.rs
+++ b/examples/hello/print/print_display/display.rs
@@ -15,13 +15,13 @@ impl fmt::Display for MinMax {
 
 // 比較のため、フィールドに名前をつけれる様な構造体を定義しましょう
 #[derive(Debug)]
-struct Point2 {
+struct Point2D {
     x: f64,
     y: f64,
 }
 
-// 先程と同様にして、Point2用の`Display`を実装しています。
-impl fmt::Display for Point2 {
+// 先程と同様にして、Point2D用の`Display`を実装しています。
+impl fmt::Display for Point2D {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // `x`と`y`のみが明示的になるようにカスタマイズ
         write!(f, "x: {}, y: {}", self.x, self.y)
@@ -42,7 +42,7 @@ fn main() {
              small = small_range,
              big = big_range);
 
-    let point = Point2 { x: 3.3, y: 7.2 };
+    let point = Point2D { x: 3.3, y: 7.2 };
 
     println!("Compare points:");
     println!("Display: {}", point);

--- a/examples/hello/print/print_display/input.md
+++ b/examples/hello/print/print_display/input.md
@@ -61,10 +61,10 @@ impl fmt::Display for Structure {
 
 ### 演習
 
-<!--- After checking the output of the above example, use the `Point2` struct as --->
+<!--- After checking the output of the above example, use the `Point2D` struct as --->
 <!--- guide to add a Complex struct to the example. When printed in the same --->
 <!--- way, the output should be: --->
-上記の例のアウトプットを確認し、`Point2`構造体を使用して、複素数を格納するための構造体を定義しましょう。うまく行けば以下のように出力されるはずです。
+上記の例のアウトプットを確認し、`Point2D`構造体を参考として、複素数を格納するための構造体を定義しましょう。うまく行けば以下のように出力されるはずです。
 
 ```
 Display: 3.3 + 7.2i


### PR DESCRIPTION
Rustの学習で利用させて頂いています。

> use the Point2D struct *as guide*

とありますので、`Point2D構造体を参考として`くらいの方が良いように感じました。