### PR TITLE
サイトのベースURLの変更

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,32 @@
+---
+title: "404 Not Found"
+permalink: /404.html
+---
+
+## 404 Not Found
+
+<div id="suggestion">
+お探しのページは存在しません。
+<a href="https://doc.rust-jp.rs">トップページ</a>からご利用ください。
+</div>
+
+<script>
+    var base_url = 'https://doc.rust-jp.rs';
+    var rbe_old = '/rust-by-example-ja/rust-by-example';
+    var rbe_new = '/rust-by-example-ja'
+
+    var href = location.href;
+    var path = location.pathname;
+    var redirect_to = '';
+
+    if (path.startsWith(rbe_old)) {
+        redirect_to = href.replace(rbe_old, rbe_new);
+    }
+
+    if (redirect_to != '') {
+        var elem = document.getElementById('suggestion');
+        elem.innerHTML = '<p>お探しのページは移動したようです。こちらのURLをお試しください。</br>'
+        elem.innerHTML += '<a href="' + redirect_to + '">' + redirect_to + '</a></p>';
+        elem.innerHTML += '<p>または、このサイトの<a href="' + base_url + '">トップページ</a>をご利用ください。</p>'
+    }
+</script>

--- a/tools/circleci/push-to-master.sh
+++ b/tools/circleci/push-to-master.sh
@@ -20,14 +20,14 @@ fi
 # Get the revision of this branch (master branch)
 REVISION=$(git rev-parse --short HEAD)
 
-mkdir -p ./docs/rust-by-example
-cp -rp ./stage/_book/* ./docs/rust-by-example
+mkdir -p ./docs
+cp -rp ./stage/_book/* ./docs/
 
 (cd ./docs; \
  # Dirty hack to enable syntax highlight in local \
- sed -i -e 's!/gitbook/plugins/gitbook-plugin-rust-playpen/mode-rust.js!/rust-by-example/gitbook/plugins/gitbook-plugin-rust-playpen/mode-rust.js!' ./rust-by-example/gitbook/plugins/gitbook-plugin-rust-playpen/editor.js)
+ sed -i -e 's!/gitbook/plugins/gitbook-plugin-rust-playpen/mode-rust.js!/rust-by-example-ja/gitbook/plugins/gitbook-plugin-rust-playpen/mode-rust.js!' ./gitbook/plugins/gitbook-plugin-rust-playpen/editor.js)
 
-cp -rp ./gitbook/* ./docs/rust-by-example/gitbook/
+cp -rp ./gitbook/* ./docs/gitbook/
 
 # If there are anything to commit, do `git commit` and `git push`
 # -f flag is needed as docs is listed in .gitignore


### PR DESCRIPTION
GitHub Pagesで公開しているURLを変更する。

- 変更前： https://doc.rust-jp.rs/rust-by-example-ja/rust-by-example/
- 変更後： https://doc.rust-jp.rs/rust-by-example-ja/

GitHub PagesではURLのリライトができないようなので、変更前のURLから変更後のURLへ自動リダイレクトはできなさそう。そこで、変更前のURLにアクセスした際には、カスタム404ページを表示し、変更後のURLをお知らせする。

Playpenについては事前の動作確認ができないので、マージしてから動作確認して、不具合があれば新たにpull requestを提出する。