### PR TITLE
Fix some translations

### DIFF
--- a/src/crates.md
+++ b/src/crates.md
@@ -11,12 +11,7 @@ places where `mod` declarations in the crate file are found, *before* running
 the compiler over it. In other words, modules do *not* get compiled
 individually, only crates get compiled.
 -->
-FIXME_EN: A crate is a compilation unit in Rust. Whenever `rustc some_file.rs` is called,
-FIXME_EN: `some_file.rs` is treated as the *crate file*. If `some_file.rs` has `mod`
-FIXME_EN: declarations in it, then the contents of the module files will get merged with
-FIXME_EN: the crate file *before* running the compiler over it. In other words, modules
-FIXME_EN: do *not* get compiled individually, only crates get compiled.
-FIXME_JA: クレイトはRustにおけるコンパイルの単位です。`rustc some_file.rs`が呼ばれると、`some_file.rs`は必ず*クレイトファイル*として扱われます。もし`some_file.rs`が`mod`宣言を含んでいるのならば、コンパイルの*前に*モジュールファイルの中身は、クレイトファイルと結合されます。言い換えると、それぞれのモジュールが独立にコンパイルされるということはありませんが、それぞれのクレートは互いに独立にコンパイルされるということです。
+クレイトはRustにおけるコンパイルの単位です。`rustc some_file.rs`が呼ばれると、`some_file.rs`は必ず*クレイトファイル*として扱われます。もし`some_file.rs`が`mod`宣言を含んでいるのならば、コンパイルの*前に*、そのモジュールファイルの中身が`mod`の位置に挿入されます。言い換えると、それぞれのモジュールが独立にコンパイルされるということはありませんが、それぞれのクレートは互いに独立にコンパイルされるということです。
 
 <!--
 A crate can be compiled into a binary or into a library. By default, `rustc`

--- a/src/error.md
+++ b/src/error.md
@@ -9,12 +9,7 @@ example, failing to read a file and then continuing to use that *bad* input
 would clearly be problematic. Noticing and explicitly managing those errors
 saves the rest of the program from various pitfalls.
 -->
-FIXME_EN: Error handling is the process of handling the possibility of failure. For
-FIXME_EN: example, failing to read a file and then continuing to use that *bad* input
-FIXME_EN: would clearly be problematic. Error handling allows us to notice and handle
-FIXME_EN: those errors in an explicit fashion, saving the rest of the program from
-FIXME_EN: potential issues.
-FIXME_JA: エラーハンドリングとは失敗の起きる可能性を扱うプロセスのことです。例えば、ファイルを読み込むのに失敗した際、その*誤った*インプットを使い続けるのは明らかに問題です。エラーハンドリングによって、そのようなエラーに気づき、よりきれいな方法で扱い、残りのプログラムに問題が波及することを防ぐことができるようになります。
+エラーハンドリングとは失敗の起きる可能性を扱うプロセスのことです。例えば、ファイルを読み込むのに失敗した際、その*誤った*インプットを使い続けるのは明らかに問題です。そのようなエラーを通知して明示的に扱うことで、残りのプログラムに問題が波及することを防ぐことができるようになります。
 
 There are various ways to deal with errors in Rust, which are described in the
 following subchapters. They all have more or less subtle differences and different

--- a/src/expression.md
+++ b/src/expression.md
@@ -42,11 +42,7 @@ assignments. The last expression in the block will be assigned to the
 place expression such as a local variable. However, if the last expression of the block ends with a
 semicolon, the return value will be `()`.
 -->
-FIXME_EN: Blocks are expressions too, so they can be used as [r-values][rvalue] in
-FIXME_EN: assignments. The last expression in the block will be assigned to the
-FIXME_EN: [l-value][lvalue]. However, if the last expression of the block ends with a
-FIXME_EN: semicolon, the return value will be `()`.
-FIXME_JA: コードブロックも文の一種です。よってブロックを丸ごと[右辺値][rvalue]として扱うことができます。その場合ブロック内の最後の式文が左辺値に代入されます。ただし、ブロック内の最後の式文が`;`で終わる場合は返り値は`()`になります。
+コードブロックも式の一種です。よってブロックを丸ごと値として扱うことができます。その場合ブロック内の最後の式が場所を表す式（例えばローカル変数）に代入されます。ただし、ブロック内の最後の式が`;`で終わる場合は返り値は`()`になります。
 
 ```rust,editable
 fn main() {

--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -3,8 +3,7 @@
 <!--
 For some use cases, when matching enums, `match` is awkward. For example:
 -->
-FIXME_EN: For some use cases, `match` is awkward. For example:
-FIXME_JA: 場合によっては`match`を使用すると不自然な書き方になってしまう場合があります。例えば...
+列挙型をマッチさせるとき、場合によっては`match`を使用すると不自然な書き方になってしまう場合があります。例えば...
 
 ```rust
 // Make `optional` of type `Option<i32>`

--- a/src/flow_control/while.md
+++ b/src/flow_control/while.md
@@ -3,8 +3,7 @@
 <!--
 The `while` keyword can be used to run a loop while a condition is true.
 -->
-FIXME_EN: The `while` keyword can be used to loop until a condition is met.
-FIXME_JA: `while`キーワードは条件が満たされるまでのループのために使用します。
+`while`キーワードは条件が真である限り実行され続けるループのために使用します。
 
 <!--
 Let's write the infamous [FizzBuzz][fizzbuzz] using a `while` loop.

--- a/src/fn/closures/closure_examples/iter_find.md
+++ b/src/fn/closures/closure_examples/iter_find.md
@@ -5,10 +5,7 @@
 first value which satisfies some condition. If none of the values satisfy the 
 condition, it returns `None`. Its signature:
 -->
-FIXME_EN: `Iterator::find` is a function which when passed an iterator, will return
-FIXME_EN: the first element which satisfies the predicate as an `Option`. Its
-FIXME_EN: signature:
-FIXME_JA: `Iterator::find`はイテレータに渡される関数で、条件を満たす最初の値を`Option`として返します。型シグネチャは以下のようになります。
+`Iterator::find`はイテレータを辿る関数で、条件を満たす最初の値を探します。もし条件を満たす値がなければ`None`を返します。型シグネチャは以下のようになります。
 
 ```rust,ignore
 pub trait Iterator {

--- a/src/fn/closures/input_functions.md
+++ b/src/fn/closures/input_functions.md
@@ -13,10 +13,7 @@ closure can be passed as a parameter.
 
 「クロージャではない普通の関数を引数として渡すことは可能なのだろうか?」
 
-FIXME_EN: about functions. And indeed they can! However, because a function can
-FIXME_EN: *never* capture variables, closures are strictly more flexible. Therefore, any
-FIXME_EN: function which can take a closure as an argument can also take a function.
-FIXME_JA: 可能です!とはいえ、通常の関数は*絶対に*周辺の変数を補足することができないので、クロージャの方がより柔軟な使い方ができます。ここから、クロージャを引数としてとる関数は、必ず通常の関数を引数としてとることができます。
+可能です!もしパラメータとしてクロージャを取る関数を定義すれば、そのクロージャのトレイト境界を満たす任意の関数をパラメータとして渡すことができます。
 
 ```rust,editable
 // Define a function which takes a generic `F` argument

--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -126,10 +126,8 @@ Implementing the `fmt::Display` trait automatically implements the
    decimals to display)
 -->
  * 上の例を実行した際に生じるエラーを修復しましょう。
- * FIXME_EN: Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
-   FIXME_EN: divided by seven to generate the estimate for Pi. (Hint: you may need to
- * FIXME_JA: `println!`マクロを追加し、`Pi is rough ly 3.143`,という文字列を出力しましょう。
-   FIXME_JA: ただし、3.143は22を7で割ることで作成してください。(ヒント: 10進数の数を出力する方法については、[`std::fmt`][fmt]をチェックする必要があるかもしれません。)
+ * `println!`マクロを追加し、表示される小数部の桁数を調整して`Pi is roughly 3.142`という文字列を出力しましょう。
+   ただし、円周率の値は`let pi = 3.141592`を使ってください。(ヒント: 小数部の桁数を調整する方法については、[`std::fmt`][fmt]をチェックする必要があるかもしれません。)
 
 ### See also:
 

--- a/src/hello/print/print_debug.md
+++ b/src/hello/print/print_debug.md
@@ -81,8 +81,7 @@ So `fmt::Debug` definitely makes this printable but sacrifices some
 elegance. Rust also provides "pretty printing" with `{:#?}`.
 -->
 `fmt::Debug`は確実にプリント可能にしてくれるのですが、一方である種の美しさを犠牲にしています。
-FIXME_EN: elegance. Manually implementing `fmt::Display` will fix that.
-FIXME_JA: `fmt::Display`を手動で実装すればその美しさを取り戻す事ができるでしょう。
+Rustは`{:#?}`による「見栄えの良いプリント」も提供します。
 
 ```rust,editable
 #[derive(Debug)]

--- a/src/macros/designators.md
+++ b/src/macros/designators.md
@@ -67,8 +67,7 @@ fn main() {
 <!--
 These are some of the available designators:
 -->
-FIXME_EN: This is a list of all the designators:
-FIXME_JA: 以下が全識別子のリストです。
+使用できる識別子には以下のようなものがあります。
 
 <!--
 * `block`

--- a/src/mod/use.md
+++ b/src/mod/use.md
@@ -7,9 +7,7 @@
 The `use` declaration can be used to bind a full path to a new name, for easier
 access. It is often used like this:
 -->
-FIXME_EN: The `use` declaration can be used to bind a full path to a new name, for easier
-FIXME_EN: access.
-FIXME_JA: `use`宣言をすることで、要素の絶対パスを新しい名前にバインドすることができ、より簡潔な記述が可能になります。
+`use`宣言をすることで、要素の絶対パスを新しい名前にバインドすることができ、より簡潔な記述が可能になります。例えば以下のように使えます。
 
 ```rust,editable,ignore
 // extern crate deeply; // normally, this would exist and not be commented out!

--- a/src/scope/borrow/alias.md
+++ b/src/scope/borrow/alias.md
@@ -9,10 +9,7 @@ borrowed, the original data can't be mutably borrowed. On the other hand, only
 *one* mutable borrow is allowed at a time. The original data can be borrowed
 again only *after* the mutable reference has been used for the last time.
 -->
-FIXME_EN: borrowed, the original data can't be mutably borrowed. On the other hand,
-FIXME_EN: only *one* mutable borrow is allowed at a time. The original data can be
-FIXME_EN: borrowed again only *after* the mutable reference goes out of scope.
-FIXME_JA: データは一度にいくつでもイミュータブルに借用することができますが、その間オリジナルのデータをミュータブルに借用することはできません。一方でミュータブルな借用は一度に*一つ*しか借用することができず、オリジナルのデータをもう一度借用するためには、ミュータブルな参照がスコープを抜けた*あとで*ないといけません。
+データは一度にいくつでもイミュータブルに借用することができますが、その間オリジナルのデータをミュータブルに借用することはできません。一方でミュータブルな借用は一度に*一つ*しか借用することができません。オリジナルのデータをもう一度借用できるのはミュータブルな参照が最後に使われた場所より*あとで*なければいけません。
 
 ```rust,editable
 struct Point { x: i32, y: i32, z: i32 }

--- a/src/scope/lifetime/elision.md
+++ b/src/scope/lifetime/elision.md
@@ -9,11 +9,7 @@ will allow you to omit them to save typing and to improve readability.
 This is known as elision. Elision exists in Rust solely because these patterns
 are common.
 -->
-FIXME_EN: Some lifetime patterns are overwelmingly common and so the borrow checker
-FIXME_EN: will implicitly add them to save typing and to improve readability.
-FIXME_EN: This process of implicit addition is called elision. Elision exists in Rust
-FIXME_EN: solely because these patterns are common.
-FIXME_JA: ライフタイムのパターンのうちのいくつかは、他と比べてあまりにも一般的に使用されるため、明示的に入力せずとも借用チェッカーが暗黙のうちに補完してくれます。これにより可読性とタイプ量を減らすことができます。
+ライフタイムのパターンのうちのいくつかは、他と比べてあまりにも一般的に使用されるため、タイプ量を減らし可読性を上げるために省くことができます。これは省略として知られており、それらのパターンが一般的であるというだけの理由で存在しています。
 
 <!--
 The following code shows a few examples of elision. For a more comprehensive

--- a/src/scope/lifetime/lifetime_bounds.md
+++ b/src/scope/lifetime/lifetime_bounds.md
@@ -21,8 +21,7 @@ in `T` must outlive `'a`.
 <!--
 The example below shows the above syntax in action used after keyword `where`:
 -->
-FIXME_EN: The example below shows the above syntax in action:
-FIXME_JA: 上記の構文を実際に動く例で見ていきましょう。
+上記の構文を実際に動く例で見ていきましょう。`where`キーワードの後に注目してください。
 
 ```rust,editable
 use std::fmt::Debug; // Trait to bound with.

--- a/src/std_misc/path.md
+++ b/src/std_misc/path.md
@@ -12,10 +12,7 @@ platform-specific `Path` variant.
 A `Path` can be created from an `OsStr`, and provides several methods to get
 information from the file/directory the path points to.
 -->
-FIXME_EN: A `Path` can be created from almost any type that implements the
-FIXME_EN: `BytesContainer` trait, like a string, and provides several methods to get
-FIXME_EN: information from the file/directory the path points to.
-FIXME_JA: `BytesContainer`トレイトを実装している型ならばほぼ全て、そこから`Path`を作成できます。例えば文字列がそうです。そうすればpathが指すファイル・ディレクトリの情報を取得するためのメソッドがいくつか使えるようになります。
+`Path`は`OsStr`から作ることができます。そうすればそのパスが指すファイル・ディレクトリの情報を取得するためのメソッドがいくつか使えるようになります。
 
 <!--
 Note that a `Path` is *not* internally represented as an UTF-8 string, but

--- a/src/types/alias.md
+++ b/src/types/alias.md
@@ -43,9 +43,7 @@ fn main() {
 The main use of aliases is to reduce boilerplate; for example the `IoResult<T>` type
 is an alias for the `Result<T, IoError>` type.
 -->
-FIXME_EN: The main use of aliases is to reduce typing; for example the `IoResult<T>` type
-FIXME_EN: is an alias for the `Result<T, IoError>` type.
-FIXME_JA: このようにエイリアスを付ける一番の理由はタイプ量を減らすことです。例えば`IoResult<T>`型は`Result<T, IoError>`の別名です。
+このようにエイリアスを付ける一番の理由はボイラープレートを減らすことです。例えば`IoResult<T>`型は`Result<T, IoError>`の別名です。
 
 ### See also:
 

--- a/src/types/inference.md
+++ b/src/types/inference.md
@@ -9,12 +9,7 @@ type of the value expression
 during an initialization. It also looks at how the variable is used afterwards 
 to infer its type. Here's an advanced example of type inference:
 -->
-FIXME_EN: The type inference engine is pretty smart. It does more than looking at the
-FIXME_EN: type of the
-FIXME_EN: [r-value][rvalue]
-FIXME_EN: during an initialization. It also looks at how the variable is used afterwards
-FIXME_EN: to infer its type. Here's an advanced example of type inference:
-FIXME_JA: Rustの型推論エンジンはなかなか賢くできています。初期化の際に右辺値([`r-value`][rvalue])の型をチェックするだけでなく、その後にどのような使われ方をしているかを見て推論します。以下がその例です。
+Rustの型推論エンジンはなかなか賢くできています。初期化の際に評価値の型をチェックするだけでなく、その後にどのような使われ方をしているかを見て推論します。以下がその例です。
 
 ```rust,editable
 fn main() {

--- a/src/types/literals.md
+++ b/src/types/literals.md
@@ -7,10 +7,7 @@
 Numeric literals can be type annotated by adding the type as a suffix. As an example, 
 to specify that the literal `42` should have the type `i32`, write `42i32`.
 -->
-FIXME_EN: Numeric literals can be type annotated by adding the type as a suffix, with the
-FIXME_EN: exception of `usize` that uses the `usize` suffix and `isize` that uses the
-FIXME_EN: `isize` suffix.
-FIXME_JA: 数値型リテラルはサフィックスを指定することで型を指定することが可能です。例外は`usize`、`isize`で、これらはそれぞれ同名のサフィックスを使用します。
+数値型リテラルはサフィックスにより型を指定することが可能です。例えば、`42`というリテラルに対して`i32`型を指定するには`42i32`とします。
 
 <!--
 The type of unsuffixed numeric literals will depend on how they are used. If no


### PR DESCRIPTION
原文が微妙に変わっている箇所について、日本語を修正しました。
FIXME_ENが元々の原文、FIXME_JAがそれに対応する日本語です。