### PR TITLE
CIで使用するDockerイメージの更新（mdbook v0.3.7, transcheck v0.2.4）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,13 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/rust-lang-ja/circleci:rust-by-example-mdbook-0.3.6
+      # For the information about software versions in the image, see the following page:
+      # https://github.com/rust-lang-ja/circleci-images/wiki/Docker%E3%82%A4%E3%83%A1%E3%83%BC%E3%82%B8%EF%BC%9ARust-by-Example
+      - image: quay.io/rust-lang-ja/circleci:rust-by-example-mdbook-0.3.7
     parallelism: 1
     steps:
       - checkout
-      # Remove .gitconfig added by Circle CI as cargo doesn't support ssh authorization
+      # Remove .gitconfig added by Circle CI as cargo doesn't support ssh authentication.
       - run: rm -f ~/.gitconfig
       - run: rm -rf docs
       - run: mdbook -V


### PR DESCRIPTION
CIで使用するDockerイメージを変更します。

Dockerイメージの内容は以下のとおりです。

- **追加**
    - mdbook-transcheck v0.2.4
- **アップデート**
    - mdbook v0.3.6 → v0.3.7
    - Rust v1.42.0 → v1.45.2

なお、上記と同等の情報はrust-lang-ja/circleci-imagesリポジトリのWikiページにもまとめてあります。
- https://github.com/rust-lang-ja/circleci-images/wiki/Dockerイメージ：Rust-by-Example
