### PR TITLE
CIで使用するDockerイメージの更新（transcheck v0.2.5）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       # For the information about software versions in the image, see the following page:
       # https://github.com/rust-lang-ja/circleci-images/wiki/Docker%E3%82%A4%E3%83%A1%E3%83%BC%E3%82%B8%EF%BC%9ARust-by-Example
-      - image: quay.io/rust-lang-ja/circleci:rust-by-example-mdbook-0.3.7
+      - image: quay.io/rust-lang-ja/circleci:rust-by-example-mdbook-0.3.7-1
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
CIで使用するDockerイメージを変更します。

Dockerイメージの内容は以下のとおりです。

- **アップデート**
    - mdbook-transcheck v0.2.4 → v0.2.5
- **変更なし**
    - mdbook v0.3.7
    - Rust v1.45.2

なお、上記と同等の情報はrust-lang-ja/circleci-imagesリポジトリのWikiページにもまとめてあります。
- https://github.com/rust-lang-ja/circleci-images/wiki/Dockerイメージ：Rust-by-Example
