### PR TITLE
符号無し整数の例に i16 が挙がっていた箇所を修正

### DIFF
--- a/src-old/primitives/input.md
+++ b/src-old/primitives/input.md
@@ -4,7 +4,7 @@ Rustは様々な基本データ型(`primitives`)の使用をサポートして�
 <!--- * signed integers: `i8`, `i16`, `i32`, `i64` and `isize` (pointer size) --->
 * 符号付き整数: `i8`, `i16`, `i32`, `i64`, `isize`（ポインタのサイズ）
 <!--- * unsigned integers: `u8`, `u16`, `u32`, `u64` and `usize` (pointer size) --->
-* 符号無し整数: `u8`, `i16`, `u32`, `u64`, `usize`（ポインタのサイズ）
+* 符号無し整数: `u8`, `u16`, `u32`, `u64`, `usize`（ポインタのサイズ）
 <!--- * floatoing point: `f32`, `f64` --->
 * 浮動小数点: `f32`, `f64`
 <!--- * `char` Unicode scalar values like `'a'`, `'α'` and `'∞'` (4 bytes each) --->

--- a/src/primitives.md
+++ b/src/primitives.md
@@ -21,7 +21,7 @@ Rustは様々な基本データ型(`primitives`)の使用をサポートして�
 * and the unit type `()`, whose only possible value is an empty tuple: `()`
 -->
 * 符号付き整数: `i8`, `i16`, `i32`, `i64`, `i128`, `isize`（ポインタのサイズ）
-* 符号無し整数: `u8`, `i16`, `u32`, `u64`, `u128`, `usize`（ポインタのサイズ）
+* 符号無し整数: `u8`, `u16`, `u32`, `u64`, `u128`, `usize`（ポインタのサイズ）
 * 浮動小数点: `f32`, `f64`
 * `char`: `'a'`, `'α'`, `'∞'`などのUnicodeのスカラー
 * `bool`: `true`または`false`


### PR DESCRIPTION
原文において u16 である箇所（https://doc.rust-jp.rs/rust-by-example-ja/primitives.html ）が i16 となっていたため修正しました。
