### PR TITLE
Update TranslationTable.md : "structure"の訳も「構造体」に

### DIFF
--- a/TranslationTable.md
+++ b/TranslationTable.md
@@ -169,7 +169,7 @@
 | string                           | 文字列
 | string interpolation             | 文字列インターポーレーション
 | struct                           | 構造体
-| structure                        | ストラクチャ
+| structure                        | 構造体
 | sum type                         | 直和型
 | symbol                           | シンボル
 | syntactic sugar                  | 糖衣構文


### PR DESCRIPTION
[Issue #86](https://github.com/rust-lang-ja/rust-by-example-ja/issues/86)
structとstructureの訳を「構造体」に統一