### PR TITLE
fix translation about "Iterator::any"

### DIFF
--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -23,7 +23,7 @@ pub trait Iterator {
         // arguments to the closure by value.
         // `FnMut`はクロージャによって補足される変数が変更される
         // 事はあっても消費されることはないということを示します。
-        // `&Self::Item`はクロージャが変数を参照として取ることを示します。
+        // `Self::Item`はクロージャが変数を値として取ることを示します。
         F: FnMut(Self::Item) -> bool {}
 }
 ```


### PR DESCRIPTION
[9.2.6.1. Iterator::any](http://doc.rust-jp.rs/rust-by-example-ja/fn/closures/closure_examples/iter_any.html)での翻訳で英文と異なっていたので、以下2点を修正しました。
- &Self::Item -> Self::Item
- 参照として取る -> 値として取る

ご確認よろしくお願いいたします。