### PR TITLE
fix typo of "scope/move"

### DIFF
--- a/src/scope/move.md
+++ b/src/scope/move.md
@@ -76,7 +76,7 @@ fn main() {
     // Since the heap memory has been freed at this point, this action would
     // result in dereferencing freed memory, but it's forbidden by the compiler
     // Error! Same reason as the previous Error
-    // この時点でヒープメモリ上の資源は開放されているので、次の操作は解放
+    // この時点でヒープメモリ上の資源は開放されているので、次の操作は
     // 解放済みメモリをデリファレンスすることになる。しかしそれはコンパイラが許さない。
     // エラー! 上述の理由より
     //println!("b contains: {}", b);


### PR DESCRIPTION
[15.2. 所有権とムーブ](http://doc.rust-jp.rs/rust-by-example-ja/scope/move.html)での翻訳で誤植がありましたので、以下1点を修正しました。
- 解放解放済み -> 解放済み

ご確認よろしくお願いいたします。