### PR TITLE
fix typo of "scope/borrow"

### DIFF
--- a/src/scope/borrow.md
+++ b/src/scope/borrow.md
@@ -51,7 +51,7 @@ fn main() {
         // Error!
         // Can't destroy `boxed_i32` while the inner value is borrowed later in scope.
         // エラー!
-        // ボックス内の要素が借用されているため、`boxed_int`を破棄する
+        // ボックス内の要素が借用されているため、`boxed_i32`を破棄する
         // ことはできない。
         eat_box_i32(boxed_i32);
         // FIXME ^ Comment out this line


### PR DESCRIPTION
[15.3. 借用](http://doc.rust-jp.rs/rust-by-example-ja/scope/borrow.html)での翻訳で変数名の誤植がありましたので、以下1点を修正しました。
- boxed_int -> boxed_i32

ご確認よろしくお願いいたします。