### PR TITLE
fix typo of "scope/borrow/ref"

### DIFF
--- a/src/scope/borrow/ref.md
+++ b/src/scope/borrow/ref.md
@@ -62,7 +62,7 @@ fn main() {
     
     {
         // Destructure `mutable_tuple` to change the value of `last`.
-        // `mutable_ tuple`をデストラクトして、`last`の値を変更
+        // `mutable_tuple`をデストラクトして、`last`の値を変更
         let (_, ref mut last) = mutable_tuple;
         *last = 2u32;
     }


### PR DESCRIPTION
[15.3.3. refパターン](http://doc.rust-jp.rs/rust-by-example-ja/scope/borrow/ref.html)での翻訳で変数名に不要なスペースがありましたので、以下1点を修正しました。
- mutable_ tuple -> mutable_tuple

ご確認よろしくお願いいたします。