### PR TITLE
fix typo of "scope/lifetime/fn"

### DIFF
--- a/src/scope/lifetime/fn.md
+++ b/src/scope/lifetime/fn.md
@@ -60,7 +60,7 @@ fn pass_x<'a, 'b>(x: &'a i32, _: &'b i32) -> &'a i32 { x }
 // reference. Then the data is dropped upon exiting the scope, leaving
 // a reference to invalid data to be returned.
 // `'a`は関数より長くなくてはならないため上の関数は正しくない。
-// ここでは、`&7`は`i32`のデータとそれへの参照を作り出す。
+// ここでは、`&String::from("foo")`は`String`のデータとそれへの参照を作り出す。
 // その後データはスコープを抜けるとともに破棄される。そのため、
 // 不適切なデータに対する参照を返すことになってしまう。
 


### PR DESCRIPTION
[15.4.2. 関数](http://doc.rust-jp.rs/rust-by-example-ja/scope/lifetime/fn.html)での翻訳で誤植がありましたので、以下1点を修正しました。
- `&7`は`i32` -> `&String::from("foo")`は`String`

ご確認よろしくお願いいたします。