### PR TITLE
fix typo of "scope/lifetime/lifetime_bounds"

### DIFF
--- a/src/scope/lifetime/lifetime_bounds.md
+++ b/src/scope/lifetime/lifetime_bounds.md
@@ -34,7 +34,7 @@ struct Ref<'a, T: 'a>(&'a T);
 // *references* in `T` must outlive `'a`. Additionally, the lifetime
 // of `Ref` may not exceed `'a`.
 // `Ref`は`'a`というライフタイムを持つジェネリック型`T`に対する参照を持ち、
-// `T`の値 *に対する参照* は必ず`'a`よりも長生きでなくてはならない。
+// `T`の値に対する *参照* は必ず`'a`よりも長生きでなくてはならない。
 // さらに、`Ref`のライフタイムは`'a`を超えてはならない。
 
 // A generic function which prints using the `Debug` trait.


### PR DESCRIPTION
[15.4.6. ライフタイム境界](http://doc.rust-jp.rs/rust-by-example-ja/scope/lifetime/lifetime_bounds.html)での翻訳でアスタリスクの囲む位置が不自然になっていたので、以下1点を修正しました。
```
`T`の値 *に対する参照* は
```
↓
 ```
 `T`の値に対する *参照*
```

ただ、「参照」を囲むのか「値 に対する参照」を囲むのか少し悩みましたが、素直に原文通り、「参照」だけを囲みました。間違っていた場合はご指摘ください。

ご確認よろしくお願いいたします。