### PR TITLE
fix typo of "error/option_unwrap"

### DIFF
--- a/src/error/option_unwrap.md
+++ b/src/error/option_unwrap.md
@@ -64,7 +64,7 @@ fn give_commoner(gift: Option<&str>) {
 // 温室育ちのお姫様はヘビを見ると`panic`します。
 fn give_princess(gift: Option<&str>) {
     // `unwrap` returns a `panic` when it receives a `None`.
-    // `unwrap`を使用すると値が`None`だった際に`panic`を返します。。
+    // `unwrap`を使用すると値が`None`だった際に`panic`を返します。
     let inside = gift.unwrap();
     if inside == "snake" { panic!("AAAaaaaa!!!!"); }
 


### PR DESCRIPTION
[18.2. Option と unwrap](http://doc.rust-jp.rs/rust-by-example-ja/error/option_unwrap.html)での翻訳で誤植がありましたので、以下1点を修正しました。
- 。。 -> 。

ご確認よろしくお願いいたします。