### PR TITLE
use宣言の未翻訳部分の日本語訳追加

### DIFF
--- a/src/mod/use.md
+++ b/src/mod/use.md
@@ -22,8 +22,10 @@ fn main() {
     my_first_function();
 }
 ```
-
+<!--
 You can use the `as` keyword to bind imports to a different name:
+-->
+`as`キーワードを使用することで、インポートを別名にバインドすることができます。
 
 ```rust,editable
 // Bind the `deeply::nested::function` path to `other_function`.


### PR DESCRIPTION
https://doc.rust-jp.rs/rust-by-example-ja/mod/use.html
に未翻訳があったため、日本語訳を追加しました