### PR TITLE
英語版とのdiffを解消

### DIFF
--- a/src/mod/use.md
+++ b/src/mod/use.md
@@ -22,6 +22,7 @@ fn main() {
     my_first_function();
 }
 ```
+
 <!--
 You can use the `as` keyword to bind imports to a different name:
 -->


### PR DESCRIPTION
CIのmdbook-transcheckで出ている英語版とのdiffを解消します。該当箇所に空行がなかったので、追加しました。

**diffの内容（Circle CIの [ジョブ](https://app.circleci.com/jobs/github/rust-lang-ja/rust-by-example-ja/312?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) より）**

```console
#!/bin/bash -eo pipefail
git submodule update --init
mdbook-transcheck src-en src

Submodule '.examples-en' (https://github.com/rust-lang/rust-by-example/) registered for path '.examples-en'
Cloning into '/root/project/.examples-en'...
Submodule path '.examples-en': checked out 'cb369ae95ca36b841960182d26f6d5d9b2e3cc18'

Error: lines has been inserted to the source file
 source --> src-en/mod/use.md:19
   |
19 | 
   |
   = hint: The lines should be inserted at src/mod/use.md:24


Exited with code exit status 1
```