### PR TITLE
CIで使用するDockerイメージを更新（mdbook-transcheck v0.2.8）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - run: rm -f ~/.gitconfig
       - run: rm -rf docs
       - run: mdbook -V
+      - run: mdbook-transcheck -V
       - run: mdbook build
       - run: mdbook test
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ jobs:
   build:
     docker:
       # For the information about software versions in the image, see the following page:
-      # https://github.com/rust-lang-ja/circleci-images/wiki/Docker%E3%82%A4%E3%83%A1%E3%83%BC%E3%82%B8%EF%BC%9ARust-by-Example
-      - image: quay.io/rust-lang-ja/circleci:rbe-mdbook-0.4.5
+      # https://github.com/rust-lang-ja/circleci-images/wiki/Docker%E3%82%A4%E3%83%A1%E3%83%BC%E3%82%B8%EF%BC%9AmdBook
+      - image: quay.io/rust-lang-ja/circleci:mdbook-0.4.14-rust-1.57.0
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
Circle CIで使用しているDockerイメージを[rbe-mdbook-*](mdbook-0.4.14-rust-1.57.0)から最新の[mdbook-*](https://github.com/rust-lang-ja/circleci-images/wiki/Docker%E3%82%A4%E3%83%A1%E3%83%BC%E3%82%B8%EF%BC%9AmdBook)へ変更することで、最新版のmdbook-transcheckを使えるようにします。

- mdbook-transcheck v0.2.8
- mdBook v0.4.14
- Rust 1.57.0