### PR TITLE
Translate the untranslated parts of `fn/closures`.

### DIFF
--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -88,8 +88,8 @@ fn main() {
 
     // The closure still mutably borrows `count` because it is called later.
     // An attempt to reborrow will lead to an error.
-    // クロージャはまだ `count` をミュータブルで借用することができる。
-    // なぜなら呼ばれのが後であるからである。
+    // クロージャはまだ `count` をミュータブルで借用している。
+    // なぜなら後で呼ばれるからである。
     // 再借用しようとするとエラーになる。
     // let _reborrow = &count; 
     // ^ TODO: try uncommenting this line.
@@ -138,7 +138,7 @@ to take ownership of captured variables:
 ```rust,editable
 fn main() {
     // `Vec` has non-copy semantics.
-    // `Vec`はコピー不可能なセマンティクスである。
+    // `Vec`はコピーセマンティクスではない。
     let haystack = vec![1, 2, 3];
 
     let contains = move |needle| haystack.contains(needle);
@@ -159,7 +159,7 @@ fn main() {
     // クロージャのシグネチャから`move`を削除すると、クロージャは _haystack_ 変数を
     // イミュータブルで借用するようになる。
     // そのため _haystack_ はまだ利用可能となり、上の行のコメントアウトを解除しても
-    // エラーを発生させなくなる。
+    // エラーが発生しなくなる。
 }
 ```
 

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -118,8 +118,12 @@ fn main() {
 }
 ```
 
+<!--
 Using `move` before vertical pipes forces closure
 to take ownership of captured variables:
+-->
+
+バーティカルパイプ（訳注：縦線記号`||`）の前に`move`を使用することで、キャプチャする変数の所有権を取ることをクロージャに強制します。
 
 ```rust,editable
 fn main() {
@@ -135,10 +139,16 @@ fn main() {
     // ^ Uncommenting above line will result in compile-time error
     // because borrow checker doesn't allow re-using variable after it
     // has been moved.
-    
+    // ^ 上の行のコメントアウトを解除すると、コンパイル時エラーになる。
+    // これは変数の所有権が移された後の再利用を借用チェッカーが許可しないからである。
+
     // Removing `move` from closure's signature will cause closure
     // to borrow _haystack_ variable immutably, hence _haystack_ is still
     // available and uncommenting above line will not cause an error.
+    // クロージャのシグネチャから`move`を削除すると、クロージャは_haystack_変数を
+    // イミュータブルで借用するようになる。
+    // そのため_haystack_はまだ利用可能となり、上の行のコメントアウトを解除しても
+    // エラーを発生させなくなる。
 }
 ```
 

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -52,10 +52,13 @@ fn main() {
 
     // `color` can be borrowed immutably again, because the closure only holds
     // an immutable reference to `color`. 
+    // `color`を再びイミュータブルで借用することができる。
+    // これはクロージャが`color`に対するイミュータブルな参照しか保持しないからである。
     let _reborrow = &color;
     print();
 
     // A move or reborrow is allowed after the final use of `print`
+    // 最後に`print`を使用した後は移動や再借用が許可される。
     let _color_moved = color;
 
 
@@ -85,16 +88,23 @@ fn main() {
 
     // The closure still mutably borrows `count` because it is called later.
     // An attempt to reborrow will lead to an error.
+    // クロージャはまだ `count` をミュータブルで借用することができる。
+    // なぜなら呼ばれのが後であるからである。
+    // 再借用しようとするとエラーになる。
     // let _reborrow = &count; 
     // ^ TODO: try uncommenting this line.
+    // ^ TODO: この行のコメントアウトを解除しましょう。
     inc();
 
     // The closure no longer needs to borrow `&mut count`. Therefore, it is
     // possible to reborrow without an error
+    // クロージャはもう`&mut count`を借用する必要がない。
+    // なので、エラーを起こさず再借用することができる。
     let _count_reborrowed = &mut count; 
 
     
     // A non-copy type.
+    // コピー不可能な型
     let movable = Box::new(3);
 
     // `mem::drop` requires `T` so this must take by value. A copy type

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -138,6 +138,7 @@ to take ownership of captured variables:
 ```rust,editable
 fn main() {
     // `Vec` has non-copy semantics.
+    // `Vec`はコピー不可能なセマンティクスである。
     let haystack = vec![1, 2, 3];
 
     let contains = move |needle| haystack.contains(needle);
@@ -151,13 +152,13 @@ fn main() {
     // has been moved.
     // ^ 上の行のコメントアウトを解除すると、コンパイル時エラーになる。
     // これは変数の所有権が移された後の再利用を借用チェッカーが許可しないからである。
-
+    
     // Removing `move` from closure's signature will cause closure
     // to borrow _haystack_ variable immutably, hence _haystack_ is still
     // available and uncommenting above line will not cause an error.
-    // クロージャのシグネチャから`move`を削除すると、クロージャは_haystack_変数を
+    // クロージャのシグネチャから`move`を削除すると、クロージャは _haystack_ 変数を
     // イミュータブルで借用するようになる。
-    // そのため_haystack_はまだ利用可能となり、上の行のコメントアウトを解除しても
+    // そのため _haystack_ はまだ利用可能となり、上の行のコメントアウトを解除しても
     // エラーを発生させなくなる。
 }
 ```

--- a/src/fn/closures/closure_examples/iter_find.md
+++ b/src/fn/closures/closure_examples/iter_find.md
@@ -60,6 +60,7 @@ fn main() {
     println!("Find 2 in array2: {:?}", array2.into_iter().find(|&&x| x == 2));
 }
 ```
+
 <!--
 `Iterator::find` gives you a reference to the item. But if you want the _index_ of the
 item, use `Iterator::position`.

--- a/src/fn/closures/closure_examples/iter_find.md
+++ b/src/fn/closures/closure_examples/iter_find.md
@@ -60,9 +60,12 @@ fn main() {
     println!("Find 2 in array2: {:?}", array2.into_iter().find(|&&x| x == 2));
 }
 ```
-
+<!--
 `Iterator::find` gives you a reference to the item. But if you want the _index_ of the
 item, use `Iterator::position`.
+-->
+`Iterator::find`はアイテムへの参照を返します。
+アイテムの _インデックス_ を使用したい場合、`Iterator::position`を使用してください。
 
 ```rust,editable
 fn main() {

--- a/src/fn/closures/closure_examples/iter_find.md
+++ b/src/fn/closures/closure_examples/iter_find.md
@@ -65,8 +65,8 @@ fn main() {
 `Iterator::find` gives you a reference to the item. But if you want the _index_ of the
 item, use `Iterator::position`.
 -->
-`Iterator::find`はアイテムへの参照を返します。
-アイテムの _インデックス_ を使用したい場合、`Iterator::position`を使用してください。
+`Iterator::find`は要素への参照を返します。
+要素の _インデックス_ を使用したい場合、`Iterator::position`を使用してください。
 
 ```rust,editable
 fn main() {

--- a/src/fn/closures/input_functions.md
+++ b/src/fn/closures/input_functions.md
@@ -24,12 +24,14 @@ fn call_me<F: Fn()>(f: F) {
 }
 
 // Define a wrapper function satisfying the `Fn` bound
+// `Fn`境界を満たすラッパ関数を定義
 fn function() {
     println!("I'm a function!");
 }
 
 fn main() {
     // Define a closure satisfying the `Fn` bound
+    // `Fn`境界を満たすクロージャを定義
     let closure = || println!("I'm a closure!");
 
     call_me(closure);

--- a/src/fn/closures/input_parameters.md
+++ b/src/fn/closures/input_parameters.md
@@ -11,7 +11,7 @@ annotated using one of a few `traits`. In order of decreasing restriction,
 they are:
 -->
 
-Rustは、ほとんど型アノテーションなしで即座に変数の捕捉をする方法を選択することができますが、関数を書く場合にはこの曖昧さは許されません。
+Rustはたいていの場合、型アノテーションなしでも変数を捕捉する方法を臨機応変に選択してくれますが、関数を書く場合にはこの曖昧さは許されません。
 引数のパラメータとしてクロージャを取る場合、そのクロージャの完全な型はいくつかの`traits`の中の1つを使って明示されなければなりません。
 制限の少ない順に並べると、下記の通りです。
 
@@ -22,7 +22,7 @@ Rustは、ほとんど型アノテーションなしで即座に変数の捕捉�
 -->
 
 * `Fn`: 参照(`&T`)によって捕捉するクロージャ
-* `FnMut`: ミュータブルな参照(`&mut T`)ミュータブルな参照によって捕捉するクロージャ
+* `FnMut`: ミュータブルな参照(`&mut T`)によって捕捉するクロージャ
 * `FnOnce`: 値(`T`)によって捕捉するクロージャ
 
 <!--
@@ -57,7 +57,7 @@ In the following example, try swapping the usage of `Fn`, `FnMut`, and
 `FnOnce` to see what happens:
 -->
 
-以下の例では、`Fn`、`FnMut`、および`FnOnce`の使用を入れ替えて、何が起こるのかを見てみましょう。
+以下の例では、`Fn`、`FnMut`、および`FnOnce`を入れ替えて、何が起こるのかを見てみましょう。
 
 ```rust,editable
 // A function which takes a closure as an argument and calls it.

--- a/src/fn/closures/input_parameters.md
+++ b/src/fn/closures/input_parameters.md
@@ -3,31 +3,61 @@
 -->
 # 捕捉時の型推論
 
+<!--
 While Rust chooses how to capture variables on the fly mostly without type
 annotation, this ambiguity is not allowed when writing functions. When
 taking a closure as an input parameter, the closure's complete type must be
 annotated using one of a few `traits`. In order of decreasing restriction,
 they are:
+-->
 
+Rustは、ほとんど型アノテーションなしで即座に変数の捕捉をする方法を選択することができますが、関数を書く場合にはこの曖昧さは許されません。
+引数のパラメータとしてクロージャを取る場合、そのクロージャの完全な型はいくつかの`traits`の中の1つを使って明示されなければなりません。
+制限の少ない順に並べると、下記の通りです。
+
+<!--
 * `Fn`: the closure captures by reference (`&T`)
 * `FnMut`: the closure captures by mutable reference (`&mut T`)
 * `FnOnce`: the closure captures by value (`T`)
+-->
 
+* `Fn`: 参照(`&T`)によって捕捉するクロージャ
+* `FnMut`: ミュータブルな参照(`&mut T`)ミュータブルな参照によって捕捉するクロージャ
+* `FnOnce`: 値(`T`)によって捕捉するクロージャ
+
+<!--
 On a variable-by-variable basis, the compiler will capture variables in the
 least restrictive manner possible.
+-->
 
+変数ごとに、コンパイラは可能な限り制約の少ない方法でその変数を捕捉します。
+
+<!--
 For instance, consider a parameter annotated as `FnOnce`. This specifies
 that the closure *may* capture by `&T`, `&mut T`, or `T`, but the compiler
 will ultimately choose based on how the captured variables are used in the
 closure.
+-->
 
+例えば、`FnOnce`というアノテーションの付けられたパラメータを考えてみましょう。
+これはそのクロージャが`&T`、`&mut T`もしくは`T`の *どれか* で捕捉することを指定するものですが、コンパイラは捕捉した変数がそのクロージャの中でどのように使用されるかに基づき、最終的に捕捉する方法を選択することになります。
+
+<!--
 This is because if a move is possible, then any type of borrow should also
 be possible. Note that the reverse is not true. If the parameter is
 annotated as `Fn`, then capturing variables by `&mut T` or `T` are not
 allowed.
+-->
 
+これは、もし移動が可能であれば、いずれの種類の借用であっても同様に可能だからです。
+その逆は正しくないことに注意してください。パラメータが`Fn`としてアノテーションされている場合、変数を`&mut T`や`T`で捕捉することは許可されません。
+
+<!--
 In the following example, try swapping the usage of `Fn`, `FnMut`, and
 `FnOnce` to see what happens:
+-->
+
+以下の例では、`Fn`、`FnMut`、および`FnOnce`の使用を入れ替えて、何が起こるのかを見てみましょう。
 
 ```rust,editable
 // A function which takes a closure as an argument and calls it.

--- a/src/fn/closures/output_parameters.md
+++ b/src/fn/closures/output_parameters.md
@@ -3,21 +3,34 @@
 -->
 # クロージャを返す関数
 
+<!--
 Closures as input parameters are possible, so returning closures as
 output parameters should also be possible. However, anonymous
 closure types are, by definition, unknown, so we have to use
 `impl Trait` to return them.
+-->
 
+クロージャを引数のパラメータとして用いることができるのと同様に、クロージャを戻り値として返すことも可能です。しかし無名のクロージャの型はその定義上、不明であるため、クロージャを返すためには`impl Trait`を使用する必要があります。
+
+<!--
 The valid traits for returning a closure are:
+-->
+
+クロージャを返すために有効なトレイトは下記の通りです。
 
 * `Fn`
 * `FnMut`
 * `FnOnce`
 
+<!--
 Beyond this, the `move` keyword must be used, which signals that all captures
 occur by value. This is required because any captures by reference would be
 dropped as soon as the function exited, leaving invalid references in the
 closure.
+-->
+
+更に、`move`というキーワードを使用し、全ての捕捉が値でおこなわれることを明示しなければなりません。
+これは、関数を抜けると同時に参照による捕捉がドロップされ、無効な参照がクロージャに残ってしまうのを防ぐためです。
 
 ```rust,editable
 fn create_fn() -> impl Fn() {


### PR DESCRIPTION
Translate the untranslated parts of the chapter [9.2. Closures](https://doc.rust-lang.org/rust-by-example/fn/closures.html) out of [9. Functions](https://doc.rust-lang.org/rust-by-example/fn.html).

[9. 関数](https://doc.rust-jp.rs/rust-by-example-ja/fn.html)のうち、[9.2. クロージャ](https://doc.rust-jp.rs/rust-by-example-ja/fn/closures.html)の章の未訳部分を翻訳しました。

## ページ全体を翻訳

- 9.2.2. 捕捉時の型推論(`src/fn/closures/input_parameters.md`)
- 9.2.5. クロージャを返す関数(`src/fn/closures/output_parameters.md`)

## ページの未訳部分を翻訳

- 9.2.1. 要素の捕捉(`src/fn/closures/capture.md`)
- 9.2.4. 関数を受け取る関数(`src/fn/closures/input_functions.md`)
- 9.2.6.2. Iterator::find(`src/fn/closures/closure_examples/iter_find.md`)
