### PR TITLE
fix: delete one line of outdated comment

### DIFF
--- a/src/custom_types/structs.md
+++ b/src/custom_types/structs.md
@@ -21,7 +21,6 @@ There are three types of structures ("structs") that can be created using the
 ```rust,editable
 #[derive(Debug)]
 struct Person {
-    // The 'a defines a lifetime
     name: String,
     age: u8,
 }


### PR DESCRIPTION
 In 3.1 Structures section, an outdated comment (a lifetime that does not exist in the source) remained in the source files, so I removed it.
I have confirmed that the comment does not exist in the original English version.