### PR TITLE
Fix typo for "捕捉"

### DIFF
--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -21,7 +21,7 @@ pub trait Iterator {
         // `FnMut` meaning any captured variable may at most be
         // modified, not consumed. `Self::Item` states it takes
         // arguments to the closure by value.
-        // `FnMut`はクロージャによって補足される変数が変更される
+        // `FnMut`はクロージャによって捕捉される変数が変更される
         // 事はあっても消費されることはないということを示します。
         // `Self::Item`はクロージャが変数を値として取ることを示します。
         F: FnMut(Self::Item) -> bool {}

--- a/src/fn/closures/closure_examples/iter_find.md
+++ b/src/fn/closures/closure_examples/iter_find.md
@@ -1,8 +1,8 @@
 # Searching through iterators
 
 <!--
-`Iterator::find` is a function which iterates over an iterator and searches for the
-first value which satisfies some condition. If none of the values satisfy the
+`Iterator::find` is a function which iterates over an iterator and searches for the 
+first value which satisfies some condition. If none of the values satisfy the 
 condition, it returns `None`. Its signature:
 -->
 `Iterator::find`はイテレータを辿る関数で、条件を満たす最初の値を探します。もし条件を満たす値がなければ`None`を返します。型シグネチャは以下のようになります。
@@ -74,8 +74,8 @@ fn main() {
 
     let index_of_first_even_number = vec.iter().position(|x| x % 2 == 0);
     assert_eq!(index_of_first_even_number, Some(5));
-
-
+    
+    
     let index_of_first_negative_number = vec.iter().position(|x| x < &0);
     assert_eq!(index_of_first_negative_number, None);
 }

--- a/src/fn/closures/closure_examples/iter_find.md
+++ b/src/fn/closures/closure_examples/iter_find.md
@@ -1,8 +1,8 @@
 # Searching through iterators
 
 <!--
-`Iterator::find` is a function which iterates over an iterator and searches for the 
-first value which satisfies some condition. If none of the values satisfy the 
+`Iterator::find` is a function which iterates over an iterator and searches for the
+first value which satisfies some condition. If none of the values satisfy the
 condition, it returns `None`. Its signature:
 -->
 `Iterator::find`はイテレータを辿る関数で、条件を満たす最初の値を探します。もし条件を満たす値がなければ`None`を返します。型シグネチャは以下のようになります。
@@ -21,7 +21,7 @@ pub trait Iterator {
         // `FnMut` meaning any captured variable may at most be
         // modified, not consumed. `&Self::Item` states it takes
         // arguments to the closure by reference.
-        // `FnMut`はクロージャによって補足される変数が変更される
+        // `FnMut`はクロージャによって捕捉される変数が変更される
         // 事はあっても消費されることはないということを示します。
         // `&Self::Item`はクロージャが変数を参照として取ることを示します。
         P: FnMut(&Self::Item) -> bool {}
@@ -74,8 +74,8 @@ fn main() {
 
     let index_of_first_even_number = vec.iter().position(|x| x % 2 == 0);
     assert_eq!(index_of_first_even_number, Some(5));
-    
-    
+
+
     let index_of_first_negative_number = vec.iter().position(|x| x < &0);
     assert_eq!(index_of_first_negative_number, None);
 }

--- a/src/fn/closures/input_functions.md
+++ b/src/fn/closures/input_functions.md
@@ -43,7 +43,7 @@ fn main() {
 As an additional note, the `Fn`, `FnMut`, and `FnOnce` `traits` dictate how
 a closure captures variables from the enclosing scope.
 -->
-クロージャによる変数の補足がどのように行われているかを詳しく見たいときは`Fn`、`FnMut`、`FnOnce`を参照してください。
+クロージャによる変数の捕捉がどのように行われているかを詳しく見たいときは`Fn`、`FnMut`、`FnOnce`を参照してください。
 
 <!--
 ### See also:

--- a/src/fn/closures/input_parameters.md
+++ b/src/fn/closures/input_parameters.md
@@ -93,7 +93,7 @@ fn main() {
 
     // Capture 2 variables: `greeting` by reference and
     // `farewell` by value.
-    // 変数を2つ補足。`greeting`は参照を、
+    // 変数を2つ捕捉。`greeting`は参照を、
     // `farewell`は値をそれぞれ捕捉する。
     let diary = || {
         // `greeting` is by reference: requires `Fn`.

--- a/src/std/option.md
+++ b/src/std/option.md
@@ -4,7 +4,7 @@
 Sometimes it's desirable to catch the failure of some parts of a program
 instead of calling `panic!`; this can be accomplished using the `Option` enum.
 -->
-プログラムの一部が失敗した際、`panic!`するよりも、エラーを補足する方が望ましい場合があります。これは`Option`という列挙型を用いることで可能になります。
+プログラムの一部が失敗した際、`panic!`するよりも、エラーを捕捉する方が望ましい場合があります。これは`Option`という列挙型を用いることで可能になります。
 
 <!--
 The `Option<T>` enum has two variants:

--- a/src/std/result.md
+++ b/src/std/result.md
@@ -3,7 +3,7 @@
 <!--
 We've seen that the `Option` enum can be used as a return value from functions
 that may fail, where `None` can be returned to indicate failure. However,
-sometimes it is important to express *why* an operation failed. To do this we 
+sometimes it is important to express *why* an operation failed. To do this we
 have the `Result` enum.
 -->
 これまでの例で、失敗する可能性のある関数の返り値として、列挙型`Option`が使用でき、失敗時の返り値には`None`を用いることを見てきました。しかし、時には **なぜ** そのオペレーションが失敗したのかを明示することが重要な場合があります。そのためには`Result`列挙型を使用します。
@@ -25,7 +25,7 @@ The `Result<T, E>` enum has two variants:
 ```rust,editable,ignore,mdbook-runnable
 mod checked {
     // Mathematical "errors" we want to catch
-    // 補足対象としたい、数学的な「エラー」
+    // 捕捉対象としたい、数学的な「エラー」
     #[derive(Debug)]
     pub enum MathError {
         DivisionByZero,

--- a/src/std/result.md
+++ b/src/std/result.md
@@ -3,7 +3,7 @@
 <!--
 We've seen that the `Option` enum can be used as a return value from functions
 that may fail, where `None` can be returned to indicate failure. However,
-sometimes it is important to express *why* an operation failed. To do this we
+sometimes it is important to express *why* an operation failed. To do this we 
 have the `Result` enum.
 -->
 これまでの例で、失敗する可能性のある関数の返り値として、列挙型`Option`が使用でき、失敗時の返り値には`None`を用いることを見てきました。しかし、時には **なぜ** そのオペレーションが失敗したのかを明示することが重要な場合があります。そのためには`Result`列挙型を使用します。


### PR DESCRIPTION
Replaced "補足" to "捕捉" when the original word is either "catch" or "capture".

原文で「catch」か「capture」が使われている場面で「補足」を「捕捉」に置き換えました。

ちなみに数カ所ほど行末の半角スペースが切り取られて(`trailing-white-space`)しまっていますので、
気になさるならばリジェクトしてください。