### PR TITLE
CIで使用するDockerイメージを更新（Rust v1.66.1）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       # For the information about software versions in the image, see the following page:
       # https://github.com/rust-lang-ja/circleci-images/wiki/Docker%E3%82%A4%E3%83%A1%E3%83%BC%E3%82%B8%EF%BC%9AmdBook
-      - image: quay.io/rust-lang-ja/circleci:mdbook-0.4.14-rust-1.57.0
+      - image: quay.io/rust-lang-ja/circleci:mdbook-0.4.25-rust-1.66.1
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
Circle CIで使用しているDockerイメージを最新版にします。

- Rust v1.66.1 (was v1.57.0)
- mdBook v0.4.25 (was v0.4.14)
- mdbook-transcheck v0.2.8 (no change)