### PR TITLE
CIに`rustc`のバージョンを表示するステップを追加する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       # Remove .gitconfig added by Circle CI as cargo doesn't support ssh authentication.
       - run: rm -f ~/.gitconfig
       - run: rm -rf docs
+      - run: rustc -Vv
       - run: mdbook -V
       - run: mdbook-transcheck -V
       - run: mdbook build


### PR DESCRIPTION
Circle CIによるCIに`rustc`のバージョンを表示するステップを追加します。`rustc`のバージョン関連で何か問題が起こったときの状況の確認に役立ちます。

なお、`mdbook`と`mdbook-transcheck`のバージョンについては、以前から表示されるようになっています。


https://app.circleci.com/pipelines/github/tatsuya6502/rust-by-example-ja/26/workflows/19b6365f-e4a3-47dd-bfa6-a34b16ad1803/jobs/72

**`rustc`のバージョンを表示するステップの実行結果**（今回追加）

```console
#!/bin/bash -eo pipefail
rustc -Vv

rustc 1.66.1 (90743e729 2023-01-10)
binary: rustc
commit-hash: 90743e7298aca107ddaa0c202a4d3604e29bfeb6
commit-date: 2023-01-10
host: x86_64-unknown-linux-gnu
release: 1.66.1
LLVM version: 15.0.2

CircleCI received exit code 0
```

**`mdbook`のバージョンを表示するステップの実行結果**（以前から存在）

```console
#!/bin/bash -eo pipefail
mdbook -V

mdbook v0.4.25

CircleCI received exit code 0
```

**`mdbook-transcheck`のバージョンを表示するステップの実行結果**（以前から存在）

```console
#!/bin/bash -eo pipefail
mdbook-transcheck -V

mdbook-transcheck 0.2.8

CircleCI received exit code 0
```