### PR TITLE
Translate and remove old lines in scope.md

### DIFF
--- a/src/variable_bindings/scope.md
+++ b/src/variable_bindings/scope.md
@@ -23,12 +23,6 @@ fn main() {
         let short_lived_binding = 2;
 
         println!("inner short: {}", short_lived_binding);
-
-        // This binding *shadows* the outer one
-        // この変数はスコープ外の同名の変数を *シャドーイング* します。
-        let long_lived_binding = 5_f32;
-
-        println!("inner long: {}", long_lived_binding);
     }
     // End of the block
     // ブロックの終わり
@@ -40,15 +34,14 @@ fn main() {
     // FIXME ^ コメントアウトしましょう
 
     println!("outer long: {}", long_lived_binding);
-    
-    // This binding also *shadows* the previous binding
-    // この変数バインディングも以前に定義した変数を *シャドーイング* します
-    let long_lived_binding = 'a';
-    
-    println!("outer long: {}", long_lived_binding);
 }
 ```
+
+<!--
 Also, [variable shadowing][variable-shadow] is allowed.
+-->
+同様に、[変数のシャドーイング][variable-shadow]も可能です。
+
 ```rust,editable,ignore,mdbook-runnable
 fn main() {
     let shadowed_binding = 1;
@@ -57,6 +50,7 @@ fn main() {
         println!("before being shadowed: {}", shadowed_binding);
 
         // This binding *shadows* the outer one
+        // この変数はスコープ外の同名の変数を *シャドーイング* します
         let shadowed_binding = "abc";
 
         println!("shadowed in inner block: {}", shadowed_binding);
@@ -64,6 +58,7 @@ fn main() {
     println!("outside inner block: {}", shadowed_binding);
 
     // This binding *shadows* the previous binding
+    // この変数バインディングは以前に定義した変数を *シャドーイング* します
     let shadowed_binding = 2;
     println!("shadowed in outer block: {}", shadowed_binding);
 }


### PR DESCRIPTION
元々あった26-31行目と43-48行目のシャドーイングの説明コードを削除しました。
[原文](https://doc.rust-lang.org/rust-by-example/variable_bindings/scope.html)では、上記が削除されており、Also以降の新しい文章が追加されているためです。

合わせて該当箇所の翻訳も行いました。