### PR TITLE
Translate untranslated files for '23. Compatibility' 

### DIFF
--- a/TranslationTable.md
+++ b/TranslationTable.md
@@ -166,6 +166,7 @@
 | r-value                          | 右辺値
 | range                            | レンジ
 | raw pointer                      | 生ポインタ
+| raw identifier                   | 生識別子
 | re-assignment                    | 再代入
 | rebind                           | 再束縛
 | reference count                  | 参照カウント

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -445,8 +445,12 @@
 - [安全でない操作](unsafe.md)
     - [Inline assembly](unsafe/asm.md)
 
+<!--
 - [Compatibility](compatibility.md)
     - [Raw identifiers](compatibility/raw_identifiers.md)
+-->
+- [互換性](compatibility.md)
+    - [生識別子](compatibility/raw_identifiers.md)
 
 <!--
 - [Meta](meta.md)

--- a/src/compatibility.md
+++ b/src/compatibility.md
@@ -1,11 +1,16 @@
 <!--
 # Compatibility
 -->
+# 互換性
 
-# Compatibility
-
+<!--
 The Rust language is fastly evolving, and because of this certain compatibility
 issues can arise, despite efforts to ensure forwards-compatibility wherever
 possible.
+-->
+Rust言語は急速に進化しており、可能な限り前方互換性を確保する努力にも関わらず、特定の互換性の問題が生じることがあります。
 
-- [Raw identifiers](compatibility/raw_identifiers.md)
+<!--
+* [Raw identifiers](compatibility/raw_identifiers.md)
+-->
+* [生識別子](compatibility/raw_identifiers.md)

--- a/src/compatibility.md
+++ b/src/compatibility.md
@@ -1,7 +1,11 @@
+<!--
+# Compatibility
+-->
+
 # Compatibility
 
 The Rust language is fastly evolving, and because of this certain compatibility
 issues can arise, despite efforts to ensure forwards-compatibility wherever
 possible.
 
-* [Raw identifiers](compatibility/raw_identifiers.md)
+- [Raw identifiers](compatibility/raw_identifiers.md)

--- a/src/compatibility/raw_identifiers.md
+++ b/src/compatibility/raw_identifiers.md
@@ -1,5 +1,9 @@
+<!--
 # Raw identifiers
+-->
+# 生識別子
 
+<!--
 Rust, like many programming languages, has the concept of "keywords".
 These identifiers mean something to the language, and so you cannot use them in
 places like variable names, function names, and other places.
@@ -7,11 +11,21 @@ Raw identifiers let you use keywords where they would not normally be allowed.
 This is particularly useful when Rust introduces new keywords, and a library
 using an older edition of Rust has a variable or function with the same name
 as a keyword introduced in a newer edition.
+-->
+Rustは多くのプログラミング言語と同様に、「キーワード」の概念を持っています。
+これらの識別子は言語にとって何かしらの意味を持ちますので、変数名や関数名、その他の場所で使用することはできません。
+生識別子は、通常は許されない状況でキーワードを使用することを可能にします。
+これは、新しいキーワードを導入したRustと、古いエディションのRustを使用したライブラリが同じ名前の変数や関数を持つ場合に特に便利です。
 
+<!--
 For example, consider a crate `foo` compiled with the 2015 edition of Rust that
 exports a function named `try`. This keyword is reserved for a new feature in
 the 2018 edition, so without raw identifiers, we would have no way to name the
 function.
+-->
+例えば、2015年エディションのRustでコンパイルされたクレート`foo`が`try`という名前の関数をエクスポートしているとします。
+このキーワードは2018年エディションで新機能として予約されていますので、生識別子がなければ、この関数を名付ける方法がありません。
+
 
 ```rust,ignore
 extern crate foo;
@@ -21,7 +35,10 @@ fn main() {
 }
 ```
 
+<!--
 You'll get this error:
+-->
+このエラーが出ます:
 
 ```text
 error: expected identifier, found keyword `try`
@@ -31,7 +48,10 @@ error: expected identifier, found keyword `try`
   |      ^^^ expected identifier, found keyword
 ```
 
+<!--
 You can write this with a raw identifier:
+-->
+これは生識別子を使って書くことができます:
 
 ```rust,ignore
 extern crate foo;


### PR DESCRIPTION
下記のファイルを翻訳します

- SUMMARY.md
- compatibility.md
- compatibility/raw_identifiers.md

### 訳語の意思決定について
- raw identifier: book-jaから拝借して生識別子と訳しました