### PR TITLE
Translate untranslated lines in supertraits.md

### DIFF
--- a/TranslationTable.md
+++ b/TranslationTable.md
@@ -194,6 +194,8 @@
 | struct                           | 構造体
 | structure                        | 構造体
 | sum type                         | 直和型
+| subtrait                         | サブトレイト
+| supertrait                       | スーパートレイト
 | symbol                           | シンボル
 | syntactic sugar                  | 糖衣構文
 | syntax tree                      | 構文木

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -294,7 +294,7 @@
     - [イテレータ](trait/iter.md)
     - [`impl Trait`](trait/impl_trait.md)
     - [クローン](trait/clone.md)
-    - [Supertraits](trait/supertraits.md)
+    - [スーパートレイト](trait/supertraits.md)
     - [Disambiguating overlapping traits](trait/disambiguating.md)
 
 <!--

--- a/src/trait/supertraits.md
+++ b/src/trait/supertraits.md
@@ -17,7 +17,7 @@ trait Person {
 
 // Person is a supertrait of Student.
 // Implementing Student requires you to also impl Person.
-// PersonはStudentの上位集合です。
+// PersonはStudentのスーパートレイトです。
 // Studentを実装するにはPersonも実装する必要があります。
 trait Student: Person {
     fn university(&self) -> String;

--- a/src/trait/supertraits.md
+++ b/src/trait/supertraits.md
@@ -1,7 +1,14 @@
+<!--
 # Supertraits
+-->
+# スーパートレイト
 
+<!--
 Rust doesn't have "inheritance", but you can define a trait as being a superset
 of another trait. For example:
+-->
+Rustには"継承"はありませんが、あるトレイトを別のトレイトの上位集合として定義できます。
+例えば：
 
 ```rust,editable
 trait Person {
@@ -10,6 +17,8 @@ trait Person {
 
 // Person is a supertrait of Student.
 // Implementing Student requires you to also impl Person.
+// PersonはStudentの上位集合です。
+// Studentを実装するにはPersonも実装する必要があります。
 trait Student: Person {
     fn university(&self) -> String;
 }
@@ -20,6 +29,8 @@ trait Programmer {
 
 // CompSciStudent (computer science student) is a subtrait of both Programmer 
 // and Student. Implementing CompSciStudent requires you to impl both supertraits.
+// CompSciStudent（コンピュータサイエンスの学生）はProgrammerとStudent両方のサブトレイトです。
+// CompSciStudentを実装するには、両方のスーパートレイトを実装する必要があります。
 trait CompSciStudent: Programmer + Student {
     fn git_username(&self) -> String;
 }


### PR DESCRIPTION
supertraitの訳は以下を参考にしました

日本語：https://doc.rust-jp.rs/book-ja/ch19-03-advanced-traits.html
原文：https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
