### PR TITLE
Fix translation of 'trait' according to translation table

### DIFF
--- a/src/error/multiple_error_types/boxing_errors.md
+++ b/src/error/multiple_error_types/boxing_errors.md
@@ -15,7 +15,7 @@ The stdlib helps in boxing our errors by having `Box` implement conversion from
 any type that implements the `Error` trait into the trait object `Box<Error>`,
 via [`From`][from].
 -->
-標準ライブラリは`Box`に、[`From`][from]を介してあらゆる`Error`トレートを実装した型から`Box<Error>`トレートオブジェクトへの変換を実装させることで、エラーをboxしやすくしてくれます。
+標準ライブラリは`Box`に、[`From`][from]を介してあらゆる`Error`トレイトを実装した型から`Box<Error>`トレイトオブジェクトへの変換を実装させることで、エラーをboxしやすくしてくれます。
 
 ```rust,editable
 use std::error;

--- a/src/error/multiple_error_types/wrap_error.md
+++ b/src/error/multiple_error_types/wrap_error.md
@@ -50,8 +50,8 @@ impl error::Error for DoubleError {
             // cast to the trait object `&error::Error`. This works because the
             // underlying type already implements the `Error` trait.
             // 元の実装のエラー型が原因。
-            // `&error::Error`トレートオブジェクトに暗にキャストされる。
-            // 元となる型が`Error`トレートをすでに実装しているため問題なく動く。
+            // `&error::Error`トレイトオブジェクトに暗にキャストされる。
+            // 元となる型が`Error`トレイトをすでに実装しているため問題なく動く。
             DoubleError::Parse(ref e) => Some(e),
         }
     }

--- a/src/error/result.md
+++ b/src/error/result.md
@@ -98,7 +98,7 @@ occurs within the `main` function it will return an error code and print a debug
 representation of the error (using the [`Debug`] trait). The following example
 shows such a scenario and touches on aspects covered in [the following section].
 -->
-一方`main`で`Result`をリターン型とすることも可能です。エラーが`main`関数内で発生した時、エラーコードを返し、エラーに関するデバッグ表記を（[`Debug`]トレートを使って）出力します。以下の例ではそのようなシナリオを示し、[この先の節]でカバーする内容に触れていきます。
+一方`main`で`Result`をリターン型とすることも可能です。エラーが`main`関数内で発生した時、エラーコードを返し、エラーに関するデバッグ表記を（[`Debug`]トレイトを使って）出力します。以下の例ではそのようなシナリオを示し、[この先の節]でカバーする内容に触れていきます。
 
 ```rust,editable
 use std::num::ParseIntError;

--- a/src/error/result/result_map.md
+++ b/src/error/result/result_map.md
@@ -16,7 +16,7 @@ the `Err` type, we look to [`parse()`][parse], which is implemented with the
 [`FromStr`][from_str] trait for [`i32`][i32]. As a result, the `Err` type is
 specified as [`ParseIntError`][parse_int_error].
 -->
-まずは、どのようなエラー型を扱っているのかを知る必要があります。`Err`型を定めるために、[`i32`][i32]に対し[`FromStr`][from_str]トレートを使って実装された[`parse()`][parse]を見てみましょう。結果、`Err`型は[`ParseIntError`][parse_int_error]というものであることが分かります。
+まずは、どのようなエラー型を扱っているのかを知る必要があります。`Err`型を定めるために、[`i32`][i32]に対し[`FromStr`][from_str]トレイトを使って実装された[`parse()`][parse]を見てみましょう。結果、`Err`型は[`ParseIntError`][parse_int_error]というものであることが分かります。
 
 <!--
 In the example below, the straightforward `match` statement leads to code


### PR DESCRIPTION
対訳表に従って、トレートと訳されていたtraitをトレイトに修正しました