### PR TITLE
Translate untranslated lines in static_lifetime.md

### DIFF
--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -116,7 +116,7 @@ It's important to understand this means that any owned data always passes
 a `'static` lifetime bound, but a reference to that owned data generally
 does not:
 -->
-ここで注意しなければいけないのは、所有権のあるデータが`'static`ライフタイム境界をパスするとしても、そのデータへの参照は`'static`ライフタイム境界をパスしないということです。
+次のポイントを押さえておきましょう。所有権のあるデータが`'static`ライフタイム境界をパスするとしても、そのデータへの参照が`'static`ライフタイム境界をパスするとは限りません。
 
 ```rust,editable,compile_fail
 use std::fmt::Debug;

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -88,7 +88,7 @@ fn main() {
         let lifetime_num = 9;
 
         // Coerce `NUM` to lifetime of `lifetime_num`:
-        // `NUM`を`lifetime_num`のライフタイムへと圧縮
+        // `NUM`を`lifetime_num`のライフタイムへと強制
         let coerced_static = coerce_static(&lifetime_num);
 
         println!("coerced_static: {}", coerced_static);

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -34,7 +34,7 @@ As a reference lifetime `'static` indicates that the data pointed to by
 the reference lives for the entire lifetime of the running program.
 It can still be coerced to a shorter lifetime.
 -->
-参照のライフタイムが`'static`であることは、参照が指し示すデータがプログラムの実行中に渡って生き続けることを示します。
+参照のライフタイムが`'static`であることは、参照が指し示す値がプログラムの実行中に渡って生き続けることを示します。
 また、より短いライフタイムに圧縮することも可能です。
 
 <!--
@@ -42,7 +42,7 @@ There are two ways to make a variable with `'static` lifetime, and both
 are stored in the read-only memory of the binary:
 -->
 `'static`ライフタイムを持つ変数を作るには下記の2つ方法があります。
-どちらの場合も、データは読み取り専用のメモリ領域に格納されます。
+どちらの場合も、値は読み取り専用のメモリ領域に格納されます。
 
 <!--
 * Make a constant with the `static` declaration.
@@ -116,7 +116,7 @@ It's important to understand this means that any owned data always passes
 a `'static` lifetime bound, but a reference to that owned data generally
 does not:
 -->
-次のポイントを押さえておきましょう。所有権のあるデータが`'static`ライフタイム境界をパスするとしても、そのデータへの参照が`'static`ライフタイム境界をパスするとは限りません。
+次のポイントを押さえておきましょう。所有権のある値が`'static`ライフタイム境界をパスするとしても、その値への参照が`'static`ライフタイム境界をパスするとは限りません。
 
 ```rust,editable,compile_fail
 use std::fmt::Debug;

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -17,17 +17,32 @@ let s: &'static str = "hello world";
 fn generic<T>(x: T) where T: 'static {}
 ```
 
+<!--
 Both are related but subtly different and this is a common source for
 confusion when learning Rust. Here are some examples for each situation:
+-->
+2つの状況における`static`は微妙に異なる意味を持っており、Rustを学ぶときの混乱の元になっています。
+いくつかの例とともにそれぞれの状況について見てみましょう。
 
+<!--
 ## Reference lifetime
+-->
+## 参照のライフタイム
 
+<!--
 As a reference lifetime `'static` indicates that the data pointed to by
 the reference lives for the entire lifetime of the running program.
 It can still be coerced to a shorter lifetime.
+-->
+参照のライフタイムが`'static`であることは、参照が指し示すデータがプログラムの実行中に渡って生き続けることを示します。
+また、より短いライフタイムに強制することも可能です。
 
+<!--
 There are two ways to make a variable with `'static` lifetime, and both
 are stored in the read-only memory of the binary:
+-->
+`'static`ライフタイムを持つ変数を作るには下記の2つ方法があります。
+どちらの場合も、データは読み取り専用のメモリ領域に格納されます。
 
 <!--
 * Make a constant with the `static` declaration.

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -88,7 +88,7 @@ fn main() {
         let lifetime_num = 9;
 
         // Coerce `NUM` to lifetime of `lifetime_num`:
-        // `NUM`を`lifetime_num`のライフタイムへと強制
+        // `NUM`を`lifetime_num`のライフタイムへと圧縮
         let coerced_static = coerce_static(&lifetime_num);
 
         println!("coerced_static: {}", coerced_static);

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -49,7 +49,7 @@ are stored in the read-only memory of the binary:
 * Make a `string` literal which has type: `&'static str`.
 -->
 * `static`宣言とともに定数を作成する。
-* 文字列リテラル で`&'static str`型を持つ変数を作成する。
+* 文字列リテラルで`&'static str`型を持つ変数を作成する。
 
 <!--
 See the following example for a display of each method:

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -22,7 +22,7 @@ Both are related but subtly different and this is a common source for
 confusion when learning Rust. Here are some examples for each situation:
 -->
 2つの状況における`static`は微妙に異なる意味を持っており、Rustを学ぶときの混乱の元になっています。
-いくつかの例とともにそれぞれの状況について見てみましょう。
+いくつかの例とともにそれぞれの使い方を見てみましょう。
 
 <!--
 ## Reference lifetime
@@ -35,7 +35,7 @@ the reference lives for the entire lifetime of the running program.
 It can still be coerced to a shorter lifetime.
 -->
 参照のライフタイムが`'static`であることは、参照が指し示すデータがプログラムの実行中に渡って生き続けることを示します。
-また、より短いライフタイムに強制することも可能です。
+また、より短いライフタイムに圧縮することも可能です。
 
 <!--
 There are two ways to make a variable with `'static` lifetime, and both
@@ -98,15 +98,25 @@ fn main() {
 }
 ```
 
+<!--
 ## Trait bound
+-->
+## トレイト境界
 
+<!--
 As a trait bound, it means the type does not contain any non-static
 references. Eg. the receiver can hold on to the type for as long as
 they want and it will never become invalid until they drop it.
+-->
+トレイト境界としての`'static`は型が非静的な参照を含まないことを意味します。
+言い換えると、レシーバはその型をいくらでも長く保持することができ、意図的にドロップするまでは決して無効になることはないということです。
 
+<!--
 It's important to understand this means that any owned data always passes
 a `'static` lifetime bound, but a reference to that owned data generally
 does not:
+-->
+ここで注意しなければいけないのは、所有権のあるデータが`'static`ライフタイム境界をパスするとしても、そのデータへの参照は`'static`ライフタイム境界をパスしないということです。
 
 ```rust,editable,compile_fail
 use std::fmt::Debug;
@@ -117,26 +127,35 @@ fn print_it( input: impl Debug + 'static ) {
 
 fn main() {
     // i is owned and contains no references, thus it's 'static:
+    // i は所有されていて、かつ参照を含まないので 'static
     let i = 5;
     print_it(i);
 
     // oops, &i only has the lifetime defined by the scope of
     // main(), so it's not 'static:
+    // おっと、&i は main() で定義されたライフタイムしかもたないため 'static ではない
     print_it(&i);
 }
 ```
+<!--
 The compiler will tell you:
+-->
+コンパイラのメッセージはこのようになります、
 ```ignore
 error[E0597]: `i` does not live long enough
+エラー[E0597]: `i`は十分なライフタイムを持っていません
   --> src/lib.rs:15:15
    |
 15 |     print_it(&i);
    |     ---------^^--
    |     |         |
    |     |         borrowed value does not live long enough
+   |     |         借用した値のライフタイムが不足
    |     argument requires that `i` is borrowed for `'static`
+   |     引数は`i`が`'static`として借用されることを要求する
 16 | }
    | - `i` dropped here while still borrowed
+   |   `i`は借用されたままここでドロップされる
 ```
 
 <!--


### PR DESCRIPTION
"data" を "データ" と訳しましたが、場所によっては "値" と訳したほうが適切なのかな？という迷いがあります。