### PR TITLE
Fix link in testcase_empty.md

### DIFF
--- a/src/generics/bounds/testcase_empty.md
+++ b/src/generics/bounds/testcase_empty.md
@@ -57,7 +57,7 @@ fn main() {
 <!--
 [`std::cmp::Eq`][eq], [`std::marker::Copy`][copy], and [`trait`s][traits]
 -->
-[`std::cmp::Eq`][eq], [`std::cmp::Ord`s][ord], [トレイト][traits]
+[`std::cmp::Eq`][eq], [`std::marker::Copy`][copy], [トレイト][traits]
 
 [eq]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 [copy]: https://doc.rust-lang.org/std/marker/trait.Copy.html


### PR DESCRIPTION
以下のページでリンクが正しく表示されていないため修正しました。
https://doc.rust-jp.rs/rust-by-example-ja/generics/bounds/testcase_empty.html

原文
https://github.com/rust-lang/rust-by-example/blob/c0be6299e52e4164c30ba6f41bd0ad0aaee64972/src/generics/bounds/testcase_empty.md?plain=1#L39